### PR TITLE
SQL Script update, resolves the bug with executing after initializati…

### DIFF
--- a/masspersona_reviews SQL scripts/Create Table and insert test data.sql
+++ b/masspersona_reviews SQL scripts/Create Table and insert test data.sql
@@ -1,13 +1,13 @@
 CREATE TABLE reviews (
-    ReviewID SERIAL PRIMARY KEY,      -- Auto-incrementing primary key
-    Title VARCHAR(255) NOT NULL,      -- The title of the media being reviewed
-    Category VARCHAR(100) NOT NULL,   -- The type of media (e.g., Movie, Book, Game)
-    ReviewText TEXT,                  -- The review text for the media
-    Rating INT CHECK (Rating >= 1 AND Rating <= 5), -- A rating out of 5
-    DateReviewed DATE NOT NULL        -- The date when the media was reviewed
+    "ReviewID" SERIAL PRIMARY KEY,      -- Auto-incrementing primary key
+    "Title" VARCHAR(255) NOT NULL,      -- The title of the media being reviewed
+    "Category" VARCHAR(100) NOT NULL,   -- The type of media (e.g., Movie, Book, Game)
+    "ReviewText" TEXT,                  -- The review text for the media
+    "Rating" INT CHECK ("Rating" >= 1 AND "Rating" <= 5), -- A rating out of 5
+    "DateReviewed" DATE NOT NULL        -- The date when the media was reviewed
 );
 
-INSERT INTO public.reviews (Title, Category, ReviewText, Rating, DateReviewed)
+INSERT INTO public.reviews ("Title", "Category", "ReviewText", "Rating", "DateReviewed")
 VALUES 
 ('The Lord of the Rings', 'Book', 'An epic fantasy novel that explores the battle between good and evil.', 5, '2024-09-30'),
 ('The Godfather', 'Movie', 'A crime drama that tells the story of a powerful mafia family.', 5, '2024-09-29'),


### PR DESCRIPTION
Updated SQL Script to properly initialize columns with case sensitivity in mind.

By default, PostgreSQL converts unquoted identifiers to lowercase.

We fixed this by adding quotes around the text for the column names. Therefore maintaining our exact casing of letters. 